### PR TITLE
Accessible table titles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "b3",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Boosts front-end framework",
   "main": "index.js",
   "repository": "git@github.com:boost/b3.git",

--- a/src/scss/theme/table.scss
+++ b/src/scss/theme/table.scss
@@ -1,0 +1,2 @@
+$table-header-cell-color: $core-text-color-default !default;
+$table-header-cell-font-weight: bold !default;

--- a/src/scss/variables.scss
+++ b/src/scss/variables.scss
@@ -7,6 +7,7 @@
 @import "theme/heading";
 @import "theme/offcanvas";
 @import "theme/search";
+@import "theme/table";
 @import "theme/text";
 @import "theme/variables";
 


### PR DESCRIPTION
Made table titles bold and not-grey so they are accessible.

**Before:**

![image](https://user-images.githubusercontent.com/15931780/109739293-4604ed80-7c2e-11eb-9f19-c2556bf2e9e4.png)

**After:**

![image](https://user-images.githubusercontent.com/15931780/109740241-dabc1b00-7c2f-11eb-9e40-3a8087d1c616.png)
