### PR TITLE
Print modifier classes & breakpoint utilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "b3",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Boosts front-end framework",
   "main": "index.js",
   "repository": "git@github.com:boost/b3.git",

--- a/src/scss/core/utilities/margin.scss
+++ b/src/scss/core/utilities/margin.scss
@@ -1,23 +1,37 @@
-@each $breakpoint, $spacing in $core-spacing {
-  $breakpoint-shorthand: map-get($core-size-shorthands, $breakpoint);
+@mixin generate-margin-classes($suffix: '') {
+  @each $breakpoint, $spacing in $core-spacing {
+    $breakpoint-shorthand: map-get($core-size-shorthands, $breakpoint);
 
-  .mt-#{$breakpoint-shorthand} { margin-top: $spacing; }
+    .mt-#{$breakpoint-shorthand}#{$suffix} { margin-top: $spacing; }
 
-  .mr-#{$breakpoint-shorthand} { margin-right: $spacing; }
+    .mr-#{$breakpoint-shorthand}#{$suffix} { margin-right: $spacing; }
 
-  .mb-#{$breakpoint-shorthand} { margin-bottom: $spacing; }
+    .mb-#{$breakpoint-shorthand}#{$suffix} { margin-bottom: $spacing; }
 
-  .ml-#{$breakpoint-shorthand} { margin-left: $spacing; }
+    .ml-#{$breakpoint-shorthand}#{$suffix} { margin-left: $spacing; }
 
-  .mx-#{$breakpoint-shorthand} {
-    margin-left: $spacing;
-    margin-right: $spacing;
+    .mx-#{$breakpoint-shorthand}#{$suffix} {
+      margin-left: $spacing;
+      margin-right: $spacing;
+    }
+
+    .my-#{$breakpoint-shorthand}#{$suffix} {
+      margin-top: $spacing;
+      margin-bottom: $spacing;
+    }
+
+    .m-#{$breakpoint-shorthand}#{$suffix} { margin: $spacing; }
   }
-
-  .my-#{$breakpoint-shorthand} {
-    margin-top: $spacing;
-    margin-bottom: $spacing;
-  }
-
-  .m-#{$breakpoint-shorthand} { margin: $spacing; }
 }
+
+// Generate default margin classes
+@include generate-margin-classes();
+
+// Generate per-breakpoint margin classes
+@media (min-width: $breakpoint-small)  { @include generate-margin-classes(\@s); }
+@media (min-width: $breakpoint-medium) { @include generate-margin-classes(\@m); }
+@media (min-width: $breakpoint-large)  { @include generate-margin-classes(\@l); }
+@media (min-width: $breakpoint-xlarge) { @include generate-margin-classes(\@xl); }
+
+// Generate print margin classes
+@media print { @include generate-margin-classes(\@p); }

--- a/src/scss/core/utilities/padding.scss
+++ b/src/scss/core/utilities/padding.scss
@@ -1,23 +1,37 @@
-@each $breakpoint, $spacing in $core-spacing {
-  $breakpoint-shorthand: map-get($core-size-shorthands, $breakpoint);
+@mixin generate-padding-classes($suffix: '') {
+  @each $breakpoint, $spacing in $core-spacing {
+    $breakpoint-shorthand: map-get($core-size-shorthands, $breakpoint);
 
-  .pt-#{$breakpoint-shorthand} { padding-top: $spacing; }
+    .pt-#{$breakpoint-shorthand}#{$suffix} { padding-top: $spacing; }
 
-  .pr-#{$breakpoint-shorthand} { padding-right: $spacing; }
+    .pr-#{$breakpoint-shorthand}#{$suffix} { padding-right: $spacing; }
 
-  .pb-#{$breakpoint-shorthand} { padding-bottom: $spacing; }
+    .pb-#{$breakpoint-shorthand}#{$suffix} { padding-bottom: $spacing; }
 
-  .pl-#{$breakpoint-shorthand} { padding-left: $spacing; }
+    .pl-#{$breakpoint-shorthand}#{$suffix} { padding-left: $spacing; }
 
-  .px-#{$breakpoint-shorthand} {
-    padding-left: $spacing;
-    padding-right: $spacing;
+    .px-#{$breakpoint-shorthand}#{$suffix} {
+      padding-left: $spacing;
+      padding-right: $spacing;
+    }
+
+    .py-#{$breakpoint-shorthand}#{$suffix} {
+      padding-top: $spacing;
+      padding-bottom: $spacing;
+    }
+
+    .p-#{$breakpoint-shorthand}#{$suffix} { padding: $spacing; }
   }
-
-  .py-#{$breakpoint-shorthand} {
-    padding-top: $spacing;
-    padding-bottom: $spacing;
-  }
-
-  .p-#{$breakpoint-shorthand} { padding: $spacing; }
 }
+
+// Generate default padding classes
+@include generate-padding-classes();
+
+// Generate per-breakpoint padding classes
+@media (min-width: $breakpoint-small)  { @include generate-padding-classes(\@s); }
+@media (min-width: $breakpoint-medium) { @include generate-padding-classes(\@m); }
+@media (min-width: $breakpoint-large)  { @include generate-padding-classes(\@l); }
+@media (min-width: $breakpoint-xlarge) { @include generate-padding-classes(\@xl); }
+
+// Generate print padding classes
+@media print { @include generate-padding-classes(\@p); }

--- a/src/scss/core/utilities/spacing.scss
+++ b/src/scss/core/utilities/spacing.scss
@@ -1,13 +1,28 @@
-@each $breakpoint, $spacing in $core-spacing {
-  $breakpoint-shorthand: map-get($core-size-shorthands, $breakpoint);
+@mixin generate-spacing-classes($suffix: '') {
+  // Iterate spacings without `none`, since it's senseless in this context.
+  @each $breakpoint, $spacing in map-remove($core-spacing, none) {
+    $breakpoint-shorthand: map-get($core-size-shorthands, $breakpoint);
 
-  .sx-#{$breakpoint-shorthand} {
-    height: $spacing;
-    width: 100%;
-  }
+    .sx-#{$breakpoint-shorthand}#{$suffix} {
+      height: $spacing;
+      width: 100%;
+    }
 
-  .sy-#{$breakpoint-shorthand} {
-    height: 100%;
-    width: $spacing;
+    .sy-#{$breakpoint-shorthand}#{$suffix} {
+      height: 100%;
+      width: $spacing;
+    }
   }
 }
+
+// Generate default spacing classes
+@include generate-spacing-classes();
+
+// Generate per-breakpoint spacing classes
+@media (min-width: $breakpoint-small)  { @include generate-spacing-classes(\@s); }
+@media (min-width: $breakpoint-medium) { @include generate-spacing-classes(\@m); }
+@media (min-width: $breakpoint-large)  { @include generate-spacing-classes(\@l); }
+@media (min-width: $breakpoint-xlarge) { @include generate-spacing-classes(\@xl); }
+
+// Generate print spacing classes
+@media print { @include generate-spacing-classes(\@p); }

--- a/src/scss/core/variables.scss
+++ b/src/scss/core/variables.scss
@@ -14,6 +14,7 @@ $core-font-family:
   "Noto Color Emoji";
 
 $core-spacing: (
+  none:   0,
   xsmall: 0.5rem,
   small:  1rem,
   medium: 1.5rem,
@@ -22,6 +23,7 @@ $core-spacing: (
 );
 
 $core-size-shorthands: (
+  none:    0,
   xsmall:  xs,
   small:   s,
   medium:  m,
@@ -29,7 +31,6 @@ $core-size-shorthands: (
   xlarge:  xl,
   2xlarge: xxl
 );
-
 
 // The amount to lighten/darken core colors for different states.
 $core-color-adjustment: 5%;

--- a/src/scss/mixins.scss
+++ b/src/scss/mixins.scss
@@ -6,7 +6,7 @@
 @import "theme/button-mixins";
 @import "theme/card-mixins";
 @import "theme/form-mixins";
+@import "theme/height-mixins";
 @import "theme/search-mixins";
 @import "theme/width-mixins";
 @import "theme/visibility-mixins";
-// @import "theme/tab-mixins";

--- a/src/scss/mixins.scss
+++ b/src/scss/mixins.scss
@@ -7,4 +7,5 @@
 @import "theme/card-mixins";
 @import "theme/form-mixins";
 @import "theme/search-mixins";
+@import "theme/width-mixins";
 // @import "theme/tab-mixins";

--- a/src/scss/mixins.scss
+++ b/src/scss/mixins.scss
@@ -8,5 +8,6 @@
 @import "theme/form-mixins";
 @import "theme/height-mixins";
 @import "theme/search-mixins";
+@import "theme/section-mixins";
 @import "theme/width-mixins";
 @import "theme/visibility-mixins";

--- a/src/scss/mixins.scss
+++ b/src/scss/mixins.scss
@@ -8,4 +8,5 @@
 @import "theme/form-mixins";
 @import "theme/search-mixins";
 @import "theme/width-mixins";
+@import "theme/visibility-mixins";
 // @import "theme/tab-mixins";

--- a/src/scss/theme/height-mixins.scss
+++ b/src/scss/theme/height-mixins.scss
@@ -11,6 +11,13 @@
     .uk-height-max-small\@p { max-height: $height-small-height; }
     .uk-height-max-medium\@p { max-height: $height-medium-height; }
     .uk-height-max-large\@p { max-height: $height-large-height; }
+
+    /*
+     * This is not part of uikit, we sometimes want to be able to remove the
+     * height of height-constrained blocks to un-scroll things in print.
+     */
+    .uk-height-auto\@p { height: auto; }
+    .uk-height-max-none\@p { max-height: none; }
   }
 }
 @mixin hook-height-misc { @include b3-height-misc; }

--- a/src/scss/theme/height-mixins.scss
+++ b/src/scss/theme/height-mixins.scss
@@ -1,0 +1,16 @@
+@mixin b3-height-misc {
+  /*
+   * Print-conditional height styling, worth nothing that all of this was copied
+   * from UIkits `uikit/src/scss/components/height.scss` breakpoint definitions.
+   */
+  @media print {
+    .uk-height-small\@p { height: $height-small-height; }
+    .uk-height-medium\@p { height: $height-medium-height; }
+    .uk-height-large\@p { height: $height-large-height; }
+
+    .uk-height-max-small\@p { max-height: $height-small-height; }
+    .uk-height-max-medium\@p { max-height: $height-medium-height; }
+    .uk-height-max-large\@p { max-height: $height-large-height; }
+  }
+}
+@mixin hook-height-misc { @include b3-height-misc; }

--- a/src/scss/theme/section-mixins.scss
+++ b/src/scss/theme/section-mixins.scss
@@ -1,0 +1,4 @@
+@mixin b3-section {
+  page-break-inside: avoid;
+}
+@mixin hook-section { @include b3-section; }

--- a/src/scss/theme/visibility-mixins.scss
+++ b/src/scss/theme/visibility-mixins.scss
@@ -1,0 +1,15 @@
+@mixin b3-visibility-misc {
+  /*
+   * Print-conditional visibility styling, worth nothing that all of this was
+   * based off of UIkits `uikit/src/scss/components/visibility.scss` breakpoint
+   * definitions.
+   */
+  @media print {
+    .uk-hidden\@p { display: none !important; }
+  }
+
+  @media screen {
+    .uk-visible\@p { display: none !important; }
+  }
+}
+@mixin hook-visibility-misc { @include b3-visibility-misc; }

--- a/src/scss/theme/width-mixins.scss
+++ b/src/scss/theme/width-mixins.scss
@@ -1,0 +1,51 @@
+@mixin b3-width-misc {
+  /*
+   * Print-conditional width styling, worth nothing that all of this was copied
+   * from UIkits `uikit/src/scss/components/width.scss` breakpoint definitions.
+   */
+  @media print {
+    /* Whole */
+    .uk-width-1-1\@p { width: 100%; }
+
+    /* Halves */
+    .uk-width-1-2\@p { width: 50%; }
+
+    /* Thirds */
+    .uk-width-1-3\@p { width: unquote('calc(100% * 1 / 3.001)'); }
+    .uk-width-2-3\@p { width: unquote('calc(100% * 2 / 3.001)'); }
+
+    /* Quarters */
+    .uk-width-1-4\@p { width: 25%; }
+    .uk-width-3-4\@p { width: 75%; }
+
+    /* Fifths */
+    .uk-width-1-5\@p { width: 20%; }
+    .uk-width-2-5\@p { width: 40%; }
+    .uk-width-3-5\@p { width: 60%; }
+    .uk-width-4-5\@p { width: 80%; }
+
+    /* Sixths */
+    .uk-width-1-6\@p { width: unquote('calc(100% * 1 / 6.001)'); }
+    .uk-width-5-6\@p { width: unquote('calc(100% * 5 / 6.001)'); }
+
+    /* Pixel */
+    .uk-width-small\@p { width: $width-small-width; }
+    .uk-width-medium\@p { width: $width-medium-width; }
+    .uk-width-large\@p { width: $width-large-width; }
+    .uk-width-xlarge\@p { width: $width-xlarge-width; }
+    .uk-width-2xlarge\@p { width: $width-2xlarge-width; }
+    @if ($deprecated == true) {
+    .uk-width-xxlarge\@p { width: $width-2xlarge-width; }
+    }
+
+    /* Auto */
+    .uk-width-auto\@p { width: auto; }
+
+    /* Expand */
+    .uk-width-expand\@p {
+      flex: 1;
+      min-width: 1px;
+    }
+  }
+}
+@mixin hook-width-misc { @include b3-width-misc; }


### PR DESCRIPTION
### What was done

Added print modifiers in convention with UiKit to their `visibility`, `width` and `height` components.
- A UiKit example width modifier `@m`, looks like `.uk-width-1-2@m` (_half parent width on medium breakpoint and up_).
- I've added a print modifier `@p`, that would look like `.uk-width-1-2@p` (_half parent width when printing_).

Added print modifiers and breakpoint modifiers to our B3 utility classes (`margin`, `padding` and `spacing`).
- e.g. `px-m@p` (_medium X padding when printing_).
- e.g. `px-m@s` (_medium X padding on small breakpoint and up_).

I also added in a `none` sizing that applies to the `margin` and `padding` utility classes. This is great when you want to specify things like _"no X padding when printing"_.
- e.g. `px-0@p` (_no X padding when printing_).

### Considerations

This adds a fair amount of extra classes that are outputted by utilities.